### PR TITLE
fix(backend): resolve swagger schema errors and missing references

### DIFF
--- a/backend/src/api/applications.rs
+++ b/backend/src/api/applications.rs
@@ -12,6 +12,22 @@ use crate::models::Application;
 use serde::Deserialize;
 
 /// Deploy an application to a node
+#[utoipa::path(
+    post,
+    path = "/api/topologies/{topology_id}/nodes/{node_id}/apps",
+    tag = "applications",
+    params(
+        ("topology_id" = Uuid, Path, description = "Topology ID"),
+        ("node_id" = String, Path, description = "Node ID")
+    ),
+    request_body = DeployAppRequest,
+    responses(
+        (status = 200, description = "App deployed", body = Application),
+        (status = 400, description = "Bad request"),
+        (status = 404, description = "Topology or node not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub async fn deploy(
     State(state): State<AppState>,
     Path((topology_id, node_id)): Path<(Uuid, String)>,
@@ -208,6 +224,20 @@ pub async fn deploy(
 }
 
 /// List all applications for a node
+#[utoipa::path(
+    get,
+    path = "/api/topologies/{topology_id}/nodes/{node_id}/apps",
+    tag = "applications",
+    params(
+        ("topology_id" = Uuid, Path, description = "Topology ID"),
+        ("node_id" = String, Path, description = "Node ID")
+    ),
+    responses(
+        (status = 200, description = "List of applications", body = Vec<Application>),
+        (status = 404, description = "Topology or node not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub async fn list_by_node(
     State(state): State<AppState>,
     Path((_topology_id, node_id)): Path<(Uuid, String)>,
@@ -221,6 +251,20 @@ pub async fn list_by_node(
 }
 
 /// Get application details
+#[utoipa::path(
+    get,
+    path = "/api/topologies/{topology_id}/apps/{app_id}",
+    tag = "applications",
+    params(
+        ("topology_id" = Uuid, Path, description = "Topology ID"),
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    responses(
+        (status = 200, description = "Application details", body = Application),
+        (status = 404, description = "Application not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub async fn get(
     State(state): State<AppState>,
     Path((_topology_id, app_id)): Path<(Uuid, Uuid)>,
@@ -271,6 +315,20 @@ pub async fn uninstall_application_by_id(
 }
 
 /// Uninstall an application
+#[utoipa::path(
+    delete,
+    path = "/api/topologies/{topology_id}/apps/{app_id}",
+    tag = "applications",
+    params(
+        ("topology_id" = Uuid, Path, description = "Topology ID"),
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    responses(
+        (status = 200, description = "Application uninstalled"),
+        (status = 404, description = "Application not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub async fn uninstall(
     State(state): State<AppState>,
     Path((_topology_id, app_id)): Path<(Uuid, Uuid)>,
@@ -369,6 +427,20 @@ async fn remove_application_from_node(
 }
 
 /// Get application logs
+#[utoipa::path(
+    get,
+    path = "/api/topologies/{topology_id}/apps/{app_id}/logs",
+    tag = "applications",
+    params(
+        ("topology_id" = Uuid, Path, description = "Topology ID"),
+        ("app_id" = Uuid, Path, description = "Application ID")
+    ),
+    responses(
+        (status = 200, description = "Application logs"),
+        (status = 404, description = "Application not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 pub async fn logs(
     State(state): State<AppState>,
     Path((_topology_id, app_id)): Path<(Uuid, Uuid)>,

--- a/backend/src/api/chaos.rs
+++ b/backend/src/api/chaos.rs
@@ -27,7 +27,7 @@ const CHAOS_NAMESPACE: &str = "networksim-sim";
         ("topology_id" = String, Path, description = "Topology ID")
     ),
     responses(
-        (status = 200, description = "List of chaos conditions", body = Vec<super::openapi::ChaosConditionSchema>),
+        (status = 200, description = "List of chaos conditions", body = Vec<ChaosCondition>),
         (status = 404, description = "Topology not found"),
         (status = 500, description = "Internal server error")
     )
@@ -56,9 +56,9 @@ pub async fn list(
     post,
     path = "/api/chaos",
     tag = "chaos",
-    request_body = super::openapi::CreateChaosRequest,
+    request_body = CreateChaosRequest,
     responses(
-        (status = 200, description = "Chaos condition created", body = super::openapi::ChaosConditionSchema),
+        (status = 200, description = "Chaos condition created", body = ChaosCondition),
         (status = 404, description = "Topology or node not found"),
         (status = 500, description = "Internal server error")
     )
@@ -138,7 +138,7 @@ pub async fn create(
         ("condition_id" = String, Path, description = "Chaos condition ID")
     ),
     responses(
-        (status = 200, description = "Chaos condition started", body = super::openapi::ChaosConditionSchema),
+        (status = 200, description = "Chaos condition started", body = ChaosCondition),
         (status = 404, description = "Condition not found"),
         (status = 500, description = "Internal server error")
     )
@@ -220,7 +220,7 @@ pub async fn start(
         ("condition_id" = String, Path, description = "Chaos condition ID")
     ),
     responses(
-        (status = 200, description = "Chaos condition stopped", body = super::openapi::ChaosConditionSchema),
+        (status = 200, description = "Chaos condition stopped", body = ChaosCondition),
         (status = 404, description = "Condition not found"),
         (status = 500, description = "Internal server error")
     )

--- a/backend/src/api/deploy.rs
+++ b/backend/src/api/deploy.rs
@@ -9,9 +9,10 @@ use crate::api::AppState;
 use crate::api::applications::deploy_application_to_node;
 use crate::error::{AppError, AppResult};
 use crate::k8s::{DeploymentManager, DeploymentState, DeploymentStatus as K8sDeploymentStatus};
+use utoipa::ToSchema;
 
 /// Response for deployment operations
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct DeploymentResponse {
     pub topology_id: String,
     pub status: String,
@@ -20,7 +21,7 @@ pub struct DeploymentResponse {
 }
 
 /// Status of a single node in a deployment
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct NodeStatusResponse {
     pub id: String,
     pub name: String,
@@ -67,7 +68,7 @@ impl From<K8sDeploymentStatus> for DeploymentResponse {
         ("id" = String, Path, description = "Topology ID")
     ),
     responses(
-        (status = 200, description = "Deployment started", body = super::openapi::DeploymentStatusSchema),
+        (status = 200, description = "Deployment started", body = DeploymentResponse),
         (status = 400, description = "Cannot deploy empty topology"),
         (status = 404, description = "Topology not found"),
         (status = 500, description = "Internal server error")
@@ -228,7 +229,7 @@ pub async fn destroy(
         ("id" = String, Path, description = "Topology ID")
     ),
     responses(
-        (status = 200, description = "Deployment status", body = super::openapi::DeploymentStatusSchema),
+        (status = 200, description = "Deployment status", body = DeploymentResponse),
         (status = 404, description = "Topology not found"),
         (status = 500, description = "Internal server error")
     )

--- a/backend/src/api/diagnostic.rs
+++ b/backend/src/api/diagnostic.rs
@@ -119,7 +119,7 @@ pub struct ContainerPort {
         ("id" = String, Path, description = "Topology ID")
     ),
     responses(
-        (status = 200, description = "Diagnostic report", body = super::openapi::DiagnosticReportSchema),
+        (status = 200, description = "Diagnostic report", body = DiagnosticReportSchema),
         (status = 400, description = "No pods deployed for this topology"),
         (status = 404, description = "Topology not found"),
         (status = 500, description = "Internal server error")
@@ -620,7 +620,7 @@ pub async fn get_node_containers(
 // ============================================================================
 
 /// Request for app-to-app connectivity test
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct AppToAppTestRequest {
     /// Source application ID
     pub from_app_id: String,

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -1,20 +1,30 @@
 use axum::{extract::State, Json};
 use serde::Serialize;
+use utoipa::ToSchema;
 
 use crate::api::AppState;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct HealthResponse {
     pub status: String,
     pub version: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, ToSchema)]
 pub struct ClusterStatusResponse {
     pub connected: bool,
     pub message: String,
 }
 
+/// System health check
+#[utoipa::path(
+    get,
+    path = "/health",
+    tag = "system",
+    responses(
+        (status = 200, description = "System is healthy", body = HealthResponse)
+    )
+)]
 pub async fn health_check() -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".to_string(),
@@ -28,7 +38,7 @@ pub async fn health_check() -> Json<HealthResponse> {
     path = "/api/cluster/status",
     tag = "cluster",
     responses(
-        (status = 200, description = "Cluster status", body = super::openapi::ClusterStatusSchema),
+        (status = 200, description = "Cluster status", body = ClusterStatusResponse),
     )
 )]
 pub async fn cluster_status(State(state): State<AppState>) -> Json<ClusterStatusResponse> {

--- a/backend/src/api/presets.rs
+++ b/backend/src/api/presets.rs
@@ -60,7 +60,7 @@ struct PresetRow {
 }
 
 /// Create preset request
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct CreatePresetRequest {
     pub name: String,
     pub description: Option<String>,
@@ -73,7 +73,7 @@ pub struct CreatePresetRequest {
 }
 
 /// Apply preset request
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct ApplyPresetRequest {
     pub source_node_id: String,
     pub target_node_id: Option<String>,
@@ -93,7 +93,7 @@ pub struct ApplyPresetRequest {
         ("category" = Option<String>, Query, description = "Filter by category")
     ),
     responses(
-        (status = 200, description = "List of all chaos presets", body = Vec<super::openapi::ChaosPresetSchema>),
+        (status = 200, description = "List of all chaos presets", body = Vec<ChaosPresetSchema>),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -180,7 +180,7 @@ pub async fn list_presets(
         ("id" = String, Path, description = "Preset ID")
     ),
     responses(
-        (status = 200, description = "Preset found", body = super::openapi::ChaosPresetSchema),
+        (status = 200, description = "Preset found", body = ChaosPresetSchema),
         (status = 404, description = "Preset not found"),
         (status = 500, description = "Internal server error")
     )
@@ -223,9 +223,9 @@ pub async fn get_preset(
     post,
     path = "/api/presets",
     tag = "presets",
-    request_body = super::openapi::CreatePresetRequest,
+    request_body = CreatePresetRequest,
     responses(
-        (status = 200, description = "Preset created", body = super::openapi::ChaosPresetSchema),
+        (status = 200, description = "Preset created", body = ChaosPresetSchema),
         (status = 500, description = "Internal server error")
     )
 )]

--- a/backend/src/api/topologies.rs
+++ b/backend/src/api/topologies.rs
@@ -54,7 +54,7 @@ struct TopologyRow {
         ("per_page" = Option<u32>, Query, description = "Items per page (max 100)")
     ),
     responses(
-        (status = 200, description = "List of all topologies", body = Vec<super::openapi::TopologySchema>),
+        (status = 200, description = "List of all topologies", body = Vec<Topology>),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -107,9 +107,9 @@ pub async fn list(
     post,
     path = "/api/topologies",
     tag = "topologies",
-    request_body = super::openapi::CreateTopologyRequest,
+    request_body = CreateTopologyRequest,
     responses(
-        (status = 200, description = "Topology created successfully", body = super::openapi::TopologySchema),
+        (status = 200, description = "Topology created successfully", body = Topology),
         (status = 400, description = "Invalid topology data"),
         (status = 500, description = "Internal server error")
     )
@@ -168,7 +168,7 @@ pub async fn create(
         ("id" = String, Path, description = "Topology ID")
     ),
     responses(
-        (status = 200, description = "Topology found", body = super::openapi::TopologySchema),
+        (status = 200, description = "Topology found", body = Topology),
         (status = 404, description = "Topology not found"),
         (status = 500, description = "Internal server error")
     )
@@ -215,9 +215,9 @@ pub async fn get(
     params(
         ("id" = String, Path, description = "Topology ID")
     ),
-    request_body = super::openapi::UpdateTopologyRequest,
+    request_body = UpdateTopologyRequest,
     responses(
-        (status = 200, description = "Topology updated", body = super::openapi::TopologySchema),
+        (status = 200, description = "Topology updated", body = Topology),
         (status = 404, description = "Topology not found"),
         (status = 500, description = "Internal server error")
     )

--- a/backend/src/chaos/types.rs
+++ b/backend/src/chaos/types.rs
@@ -2,9 +2,10 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Types of chaos conditions that can be applied
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ChaosType {
     // ---- NetworkChaos types ----
@@ -91,7 +92,7 @@ impl ChaosType {
 }
 
 /// Parameters for delay chaos
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct DelayParams {
     /// Latency to add (e.g., "100ms", "1s")
     pub latency: String,
@@ -104,7 +105,7 @@ pub struct DelayParams {
 }
 
 /// Parameters for packet loss chaos
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct LossParams {
     /// Loss percentage (e.g., "25" for 25%)
     pub loss: String,
@@ -114,7 +115,7 @@ pub struct LossParams {
 }
 
 /// Parameters for bandwidth limiting
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct BandwidthParams {
     /// Rate limit (e.g., "1mbps", "100kbps")
     pub rate: String,
@@ -127,7 +128,7 @@ pub struct BandwidthParams {
 }
 
 /// Parameters for packet corruption
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct CorruptParams {
     /// Corruption percentage (e.g., "10")
     pub corrupt: String,
@@ -137,7 +138,7 @@ pub struct CorruptParams {
 }
 
 /// Parameters for packet duplication
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct DuplicateParams {
     /// Duplication percentage
     pub duplicate: String,
@@ -149,7 +150,7 @@ pub struct DuplicateParams {
 // ---- New chaos type parameters ----
 
 /// Parameters for CPU stress (StressChaos)
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct StressCpuParams {
     /// Number of CPU stress workers
     #[serde(default)]
@@ -160,7 +161,7 @@ pub struct StressCpuParams {
 }
 
 /// Parameters for pod kill (PodChaos)
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct PodKillParams {
     /// Grace period in seconds before killing
     #[serde(default)]
@@ -168,7 +169,7 @@ pub struct PodKillParams {
 }
 
 /// Parameters for I/O delay (IOChaos)
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct IoDelayParams {
     /// Delay to add to I/O operations (e.g., "100ms")
     pub delay: String,
@@ -184,7 +185,7 @@ pub struct IoDelayParams {
 }
 
 /// Parameters for HTTP abort (HTTPChaos)
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct HttpAbortParams {
     /// HTTP status code to return (e.g., 500, 429)
     #[serde(default)]
@@ -201,7 +202,7 @@ pub struct HttpAbortParams {
 }
 
 /// Union of all chaos parameters
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
 #[derive(Default)]
 pub enum ChaosParams {
@@ -222,7 +223,7 @@ pub enum ChaosParams {
 }
 
 /// Target direction for network chaos
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum ChaosDirection {
     /// Apply to outgoing traffic
@@ -245,7 +246,7 @@ impl std::fmt::Display for ChaosDirection {
 }
 
 /// Request to create a chaos condition
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateChaosRequest {
     /// Topology ID the chaos applies to
     pub topology_id: String,
@@ -267,7 +268,7 @@ pub struct CreateChaosRequest {
 }
 
 /// Request to update a chaos condition (only editable fields)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateChaosRequest {
     /// Direction of traffic to affect
     #[serde(default)]
@@ -280,7 +281,7 @@ pub struct UpdateChaosRequest {
 }
 
 /// Status of a chaos condition in the system
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ChaosConditionStatus {
     /// Created but not yet applied to K8s
@@ -315,7 +316,7 @@ impl std::str::FromStr for ChaosConditionStatus {
 }
 
 /// A chaos condition that has been applied
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ChaosCondition {
     /// Unique ID
     pub id: String,

--- a/backend/src/helm/types.rs
+++ b/backend/src/helm/types.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
+use utoipa::ToSchema;
 
 /// Estado de una aplicación Helm
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, ToSchema)]
 #[sqlx(type_name = "TEXT")]
 #[serde(rename_all = "lowercase")]
 pub enum AppStatus {
@@ -15,7 +16,7 @@ pub enum AppStatus {
 }
 
 /// Información de una aplicación desplegada con Helm
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Application {
     pub id: Uuid,
     pub node_id: String,
@@ -31,17 +32,20 @@ pub struct Application {
 }
 
 /// Request para desplegar una aplicación
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DeployAppRequest {
     pub chart: String,
     pub chart_type: Option<String>,
     pub node_selector: Vec<String>,
     
     // Configuración detallada que el frontend envía plana
+    #[schema(value_type = Option<Object>)]
     pub envvalues: Option<serde_json::Value>,
     pub replicas: Option<i32>,
+    #[schema(value_type = Option<Vec<Object>>)]
     pub volumes: Option<Vec<serde_json::Value>>, // Usamos Value para ser flexibles con los tipos de volumen
     #[serde(rename = "healthCheck")]
+    #[schema(value_type = Option<Object>)]
     pub health_check: Option<serde_json::Value>,
     pub cpu_request: Option<String>,
     pub memory_request: Option<String>,

--- a/backend/src/models/application.rs
+++ b/backend/src/models/application.rs
@@ -3,9 +3,10 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use sqlx::FromRow;
 use strum::Display;
+use utoipa::ToSchema;
 
 /// Estado de una aplicación Helm
-#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, Display, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::Type, Display, PartialEq, ToSchema)]
 #[sqlx(type_name = "TEXT")]
 #[serde(rename_all = "lowercase")]
 pub enum AppStatus {
@@ -36,7 +37,7 @@ impl From<&str> for AppStatus {
 }
 
 /// Modelo de base de datos para aplicaciones desplegadas con Helm
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Application {
     pub id: Uuid,
     pub topology_id: Uuid,

--- a/backend/src/models/topology.rs
+++ b/backend/src/models/topology.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use utoipa::ToSchema;
 
 /// A network topology containing nodes and links
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Topology {
     pub id: String,
     pub name: String,
@@ -16,7 +17,7 @@ pub struct Topology {
 }
 
 /// A node in the network topology
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Node {
     pub id: String,
     pub name: String,
@@ -26,14 +27,14 @@ pub struct Node {
 }
 
 /// Position of a node on the canvas
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct Position {
     pub x: f64,
     pub y: f64,
 }
 
 /// Configuration for a node
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct NodeConfig {
     #[serde(default)]
     pub image: Option<String>,
@@ -46,14 +47,14 @@ pub struct NodeConfig {
 }
 
 /// Environment variable
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct EnvVar {
     pub name: String,
     pub value: String,
 }
 
 /// A link between two nodes
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Link {
     pub id: String,
     pub source: String,
@@ -63,7 +64,7 @@ pub struct Link {
 }
 
 /// Properties of a link
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, ToSchema)]
 pub struct LinkProperties {
     #[serde(default)]
     pub bandwidth: Option<String>,
@@ -72,7 +73,7 @@ pub struct LinkProperties {
 }
 
 /// Request to create a new topology
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateTopologyRequest {
     pub name: Option<String>,
     #[serde(default)]
@@ -84,7 +85,7 @@ pub struct CreateTopologyRequest {
 }
 
 /// Request to update an existing topology
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateTopologyRequest {
     pub name: Option<String>,
     #[serde(default)]


### PR DESCRIPTION
- Derive ToSchema for domain models (Topology, Chaos, Deployment, etc.)
- Register missing schemas in OpenApi definiton
- Remove duplicate/manual schema structs in openapi.rs
- Fix relative path references in utoipa decorators
- Resolve all 'Could not resolve reference' warnings